### PR TITLE
Apply BinSkim Patch to VCPKG

### DIFF
--- a/ports/openssl/binskim.patch
+++ b/ports/openssl/binskim.patch
@@ -1,0 +1,24 @@
+diff --git a/Configurations/10-main.conf b/Configurations/10-main.conf
+index 8ca8235..d43e220 100644
+--- a/Configurations/10-main.conf
++++ b/Configurations/10-main.conf
+@@ -1231,8 +1231,9 @@ my %targets = (
+         template         => 1,
+         CC               => "cl",
+         CPP              => '$(CC) /EP /C',
+-        CFLAGS           => "/W3 /wd4090 /nologo",
+-        LDFLAGS          => add("/debug"),
++        CFLAGS           => "/W3 /wd4090 /nologo /guard:cf /ZH:SHA_256 /Qspectre /sdl",
++        LDFLAGS          => add(picker(debug => "/debug /DYNAMICBASE /CETCOMPAT",
++                                       release => "/debug /opt:ref,icf /incremental:no /DYNAMICBASE /CETCOMPAT")),
+         coutflag         => "/Fo",
+         defines          => add("OPENSSL_SYS_WIN32", "WIN32_LEAN_AND_MEAN",
+                                 "UNICODE", "_UNICODE",
+@@ -1240,6 +1241,7 @@ my %targets = (
+                                 "_WINSOCK_DEPRECATED_NO_WARNINGS"),
+         lib_cflags       => add("/Zi /Fdossl_static.pdb"),
+         lib_defines      => add("L_ENDIAN"),
++		 lflags           => add('/guard:cf /DYNAMICBASE'),
+         dso_cflags       => "/Zi /Fddso.pdb",
+         bin_cflags       => "/Zi /Fdapp.pdb",
+         shared_ldflag    => "/dll",

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -31,6 +31,7 @@ vcpkg_from_github(
         unix/move-openssldir.patch
         unix/no-empty-dirs.patch
         unix/no-static-libs-for-shared.patch
+        binskim-openssl.patch
 )
 
 vcpkg_list(SET CONFIGURE_OPTIONS


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
